### PR TITLE
jit: Fix ps1 handling in fused multiply-add instructions.

### DIFF
--- a/src/libcpu/src/jit/jit_float.cpp
+++ b/src/libcpu/src/jit/jit_float.cpp
@@ -2,6 +2,7 @@
 #include "jit_float.h"
 #include "common/bitutils.h"
 #include "common/decaf_assert.h"
+#include "common/log.h"
 #include <cstdint>
 
 namespace cpu
@@ -9,6 +10,31 @@ namespace cpu
 
 namespace jit
 {
+
+static bool
+hostHasFMA3()
+{
+   static bool checked = false;
+   static bool hasFMA3;
+
+   if (!checked) {
+      checked = true;
+#ifdef PLATFORM_WINDOWS
+      int cpuInfo[4];
+      __cpuid(cpuInfo, 1);
+      hasFMA3 = ((cpuInfo[2] & (1 << 12)) != 0);
+#else
+      uint32_t ecx;
+      __asm__("cpuid" : "=c" (ecx) : "a" (1) : "rax", "rbx", "rdx");
+      hasFMA3 = ((ecx & (1 << 12)) != 0);
+#endif
+      if (!hasFMA3) {
+         gLog->warn("FMA3 instructions not available; fused multiply-add results will be inaccurate");
+      }
+   }
+
+   return hasFMA3;
+}
 
 static void
 truncateToSingleSd(PPCEmuAssembler& a, const PPCEmuAssembler::XmmRegister& reg)
@@ -207,7 +233,7 @@ fsubs(PPCEmuAssembler& a, Instruction instr)
    return fsubGeneric<true>(a, instr);
 }
 
-template <bool ShouldTruncate, bool ShouldNegate>
+template <bool ShouldTruncate, bool ShouldSubtract, bool ShouldNegate>
 static bool
 fmaddGeneric(PPCEmuAssembler& a, Instruction instr)
 {
@@ -217,108 +243,97 @@ fmaddGeneric(PPCEmuAssembler& a, Instruction instr)
 
    // FPSCR, FPRF supposed to be updated here...
 
-   auto dst = a.loadRegisterWrite(a.fprps[instr.frD]);
-
+   auto result = a.allocXmmTmp();
    {
+      auto srcC = a.loadRegisterRead(a.fprps[instr.frC]);
+      // Do the rounding first so we don't run out of host registers
+      if (ShouldTruncate) {
+         auto tmpSrcC = a.allocXmmTmp(srcC);
+         truncateTo24BitSd(a, tmpSrcC);
+         srcC = tmpSrcC;
+      }
       auto srcA = a.loadRegisterRead(a.fprps[instr.frA]);
-      auto tmpSrcB = a.allocXmmTmp(a.loadRegisterRead(a.fprps[instr.frB]));
-      auto tmpSrcC = a.allocXmmTmp(a.loadRegisterRead(a.fprps[instr.frC]));
-      a.movq(dst, srcA);
-      a.mulsd(dst, tmpSrcC);
-      a.addsd(dst, tmpSrcB);
+      auto srcB = a.loadRegisterRead(a.fprps[instr.frB]);
+
+      a.movq(result, srcA);
+      if (hostHasFMA3()) {
+         if (ShouldSubtract) {
+            a.vfmsub132sd(result, srcB, srcC);
+         } else {
+            a.vfmadd132sd(result, srcB, srcC);
+         }
+      } else {  // no FMA3
+         a.mulsd(result, srcC);
+         if (ShouldSubtract) {
+            a.subsd(result, srcB);
+         } else {
+            a.addsd(result, srcB);
+         }
+      }
    }
 
    if (ShouldNegate) {
-      negateXmmSd(a, dst);
+      negateXmmSd(a, result);
    }
 
    if (ShouldTruncate) {
-      truncateToSingleSd(a, dst);
+      truncateToSingleSd(a, result);
+      auto dst = a.loadRegisterWrite(a.fprps[instr.frD]);
+      a.movddup(dst, result);
+   } else {
+      auto dst = a.loadRegisterReadWrite(a.fprps[instr.frD]);
+      a.movsd(dst, result);
    }
 
-   a.movddup(dst, dst);
    return true;
 }
 
 static bool
 fmadd(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmaddGeneric<false, false>(a, instr);
+   return fmaddGeneric<false, false, false>(a, instr);
 }
 
 static bool
 fmadds(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmaddGeneric<true, false>(a, instr);
-}
-
-template <bool ShouldTruncate, bool ShouldNegate>
-static bool
-fmsubGeneric(PPCEmuAssembler& a, Instruction instr)
-{
-   if (instr.rc) {
-      return jit_fallback(a, instr);
-   }
-
-   // FPSCR, FPRF supposed to be updated here...
-
-   auto dst = a.loadRegisterWrite(a.fprps[instr.frD]);
-
-   {
-      auto srcA = a.loadRegisterRead(a.fprps[instr.frA]);
-      auto tmpSrcB = a.allocXmmTmp(a.loadRegisterRead(a.fprps[instr.frB]));
-      auto tmpSrcC = a.allocXmmTmp(a.loadRegisterRead(a.fprps[instr.frC]));
-      a.movq(dst, srcA);
-      a.mulsd(dst, tmpSrcC);
-      a.subsd(dst, tmpSrcB);
-   }
-
-   if (ShouldNegate) {
-      negateXmmSd(a, dst);
-   }
-
-   if (ShouldTruncate) {
-      truncateToSingleSd(a, dst);
-   }
-
-   a.movddup(dst, dst);
-   return true;
+   return fmaddGeneric<true, false, false>(a, instr);
 }
 
 static bool
 fmsub(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmsubGeneric<false, false>(a, instr);
+   return fmaddGeneric<false, true, false>(a, instr);
 }
 
 static bool
 fmsubs(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmsubGeneric<true, false>(a, instr);
+   return fmaddGeneric<true, true, false>(a, instr);
 }
 
 static bool
 fnmadd(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmaddGeneric<false, true>(a, instr);
+   return fmaddGeneric<false, false, true>(a, instr);
 }
 
 static bool
 fnmadds(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmaddGeneric<true, true>(a, instr);
+   return fmaddGeneric<true, false, true>(a, instr);
 }
 
 static bool
 fnmsub(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmsubGeneric<false, true>(a, instr);
+   return fmaddGeneric<false, true, true>(a, instr);
 }
 
 static bool
 fnmsubs(PPCEmuAssembler& a, Instruction instr)
 {
-   return fmsubGeneric<true, true>(a, instr);
+   return fmaddGeneric<true, true, true>(a, instr);
 }
 
 static bool


### PR DESCRIPTION
Also use Intel FMA3 instructions when available to avoid loss of
precision in the result.