### PR TITLE
interpreter: Work around a stupid LLVM bug.

### DIFF
--- a/src/common/platform_compiler.h
+++ b/src/common/platform_compiler.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Macro to disable optimization when building with Clang on a function which
+//  both performs floating-point operations and checks exception flags that
+//  could be affected by those operations.  This is required because LLVM is
+//  unaware of the fact that floating-point operations can raise exceptions
+//  (see http://llvm.org/bugs/show_bug.cgi?id=6050).  Place this immediately
+//  before the opening brace for the function.
+#ifdef __clang__
+#define CLANG_FPU_BUG_WORKAROUND __attribute__((optnone))
+#else
+#define CLANG_FPU_BUG_WORKAROUND //nothing
+#endif

--- a/src/libcpu/src/interpreter/interpreter_pairedsingle.cpp
+++ b/src/libcpu/src/interpreter/interpreter_pairedsingle.cpp
@@ -3,6 +3,7 @@
 #include "interpreter_insreg.h"
 #include "interpreter_float.h"
 #include "common/floatutils.h"
+#include "common/platform_compiler.h"
 
 // Register move / sign bit manipulation
 enum MoveMode
@@ -261,7 +262,7 @@ ps_div(cpu::Core *state, Instruction instr)
 
 template<int slot>
 static void
-psSumGeneric(cpu::Core *state, Instruction instr)
+psSumGeneric(cpu::Core *state, Instruction instr) CLANG_FPU_BUG_WORKAROUND
 {
    const uint32_t oldFPSCR = state->fpscr.value;
    float d;


### PR DESCRIPTION
LLVM miscompiles code which checks floating-point exceptions because it
doesn't know about them (http://llvm.org/bugs/show_bug.cgi?id=6050).
This affects the ps_sum1 implementation, so work around it by disabling
optimization for that function when building with Clang.