### PR TITLE
opengl: Fix failure to reuse color buffers as textures.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/glsl2_tex.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_tex.cpp
@@ -165,6 +165,19 @@ sampleFunc(State &state,
 
       insertSelectVector(state.out, src, srcSelX, srcSelY, srcSelZ, srcSelW, samplerElements);
 
+      // TODO: Possible performance bottleneck; this could be improved by
+      //  skipping the multiply for textures whose guest and host size are
+      //  equal, though that requires including the equality test as part of
+      //  the shader key.
+      state.out << " * ";
+      insertSelectVector(state.out,
+                         fmt::format("texScale[{}]", resourceID),
+                         latte::SQ_SEL_X,
+                         latte::SQ_SEL_Y,
+                         latte::SQ_SEL_Z,
+                         latte::SQ_SEL_W,
+                         samplerElements);
+
       switch (extraArg) {
       case latte::SQ_SEL_X:
          state.out << ", ";

--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
@@ -595,6 +595,8 @@ insertFileHeader(State &state)
    }
 
    // Samplers
+   bool hasSamplers = false;
+
    for (auto id = 0u; id < state.shader->samplerDim.size(); ++id) {
       auto dim = state.shader->samplerDim[id];
       auto usage = state.shader->samplerUsage[id];
@@ -603,6 +605,8 @@ insertFileHeader(State &state)
       if (usage == SamplerUsage::Invalid) {
          continue;
       }
+
+      hasSamplers = true;
 
       out << "layout (binding = " << id << ") uniform ";
 
@@ -669,6 +673,10 @@ insertFileHeader(State &state)
       }
 
       out << " sampler_" << id << ";\n";
+   }
+
+   if (hasSamplers) {
+      out << "uniform vec4 texScale[" << latte::MaxTextures << "];\n";
    }
 
    if (state.shader->type == Shader::VertexShader) {

--- a/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
@@ -122,7 +122,7 @@ GLDriver::getColorBuffer(latte::CB_COLORN_BASE cb_color_base,
       decaf_abort(fmt::format("Color buffer with unsupported number type {}", cbNumberType));
    }
 
-   auto buffer = getSurfaceBuffer(baseAddress, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false);
+   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false);
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_MAG_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_MIN_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_WRAP_S, static_cast<int>(gl::GL_CLAMP_TO_EDGE));

--- a/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
@@ -110,7 +110,7 @@ GLDriver::getDepthBuffer(latte::DB_DEPTH_BASE db_depth_base,
       decaf_abort(fmt::format("Depth buffer with unsupported format {}", dbFormat));
    }
 
-   auto buffer = getSurfaceBuffer(baseAddress, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, true);
+   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, true);
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_MAG_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_MIN_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->object, gl::GL_TEXTURE_WRAP_S, static_cast<int>(gl::GL_CLAMP_TO_EDGE));

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -31,6 +31,7 @@ GLDriver::initGL()
       applyRegister(static_cast<latte::Register>(i*4));
    }
    mActiveShader = nullptr;
+   mTexCoordScale.fill(1.0f);
    mActiveDepthBuffer = nullptr;
    memset(&mActiveColorBuffers[0], 0, sizeof(SurfaceBuffer *) * mActiveColorBuffers.size());
 

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -74,6 +74,7 @@ struct VertexShader : public Resource
 {
    gl::GLuint object = 0;
    gl::GLuint uniformRegisters = 0;
+   gl::GLuint uniformTexScale = 0;
    std::array<gl::GLuint, latte::MaxAttributes> attribLocations;
    std::array<uint8_t, 256> outputMap;
    std::array<bool, 16> usedUniformBlocks;
@@ -87,6 +88,7 @@ struct PixelShader : public Resource
    gl::GLuint object = 0;
    gl::GLuint uniformRegisters = 0;
    gl::GLuint uniformAlphaRef = 0;
+   gl::GLuint uniformTexScale = 0;
    std::array<SamplerType, latte::MaxSamplers> samplerTypes;
    latte::SX_ALPHA_TEST_CONTROL sx_alpha_test_control;
    std::array<bool, 16> usedUniformBlocks;
@@ -110,12 +112,13 @@ struct Shader
 struct SurfaceBuffer : Resource
 {
    gl::GLuint object = 0;
+   uint32_t width = 0;
+   uint32_t height = 0;
+   uint32_t depth = 0;
    SurfaceUseState state = SurfaceUseState::None;
    bool dirtyAsTexture = true;
    uint64_t cpuMemHash[2] = { 0 };
    struct {
-      uint32_t width = 0;
-      uint32_t height = 0;
       uint32_t depth = 0;
       latte::SQ_TEX_DIM dim;
       latte::SQ_DATA_FORMAT format;
@@ -266,9 +269,16 @@ private:
                       const gsl::span<std::pair<uint32_t, uint32_t>> &registers);
 
    SurfaceBuffer *
-   getSurfaceBuffer(ppcaddr_t baseAddress, uint32_t width, uint32_t height, uint32_t depth,
-                    latte::SQ_TEX_DIM dim, latte::SQ_DATA_FORMAT format, latte::SQ_NUM_FORMAT numFormat,
-                    latte::SQ_FORMAT_COMP formatComp, uint32_t degamma, bool isDepthBuffer);
+   getSurfaceBuffer(ppcaddr_t baseAddress,
+                    uint32_t pitch,
+                    uint32_t width,
+                    uint32_t height,
+                    uint32_t depth,
+                    latte::SQ_TEX_DIM dim,
+                    latte::SQ_DATA_FORMAT format,
+                    latte::SQ_NUM_FORMAT numFormat,
+                    latte::SQ_FORMAT_COMP formatComp,
+                    uint32_t degamma, bool isDepthBuffer);
 
    SurfaceBuffer *
    getColorBuffer(latte::CB_COLORN_BASE base,
@@ -342,6 +352,8 @@ private:
    std::array<Sampler, latte::MaxSamplers> mVertexSamplers;
    std::array<Sampler, latte::MaxSamplers> mPixelSamplers;
    std::array<Sampler, latte::MaxSamplers> mGeometrySamplers;
+
+   std::array<float, latte::MaxTextures * 4> mTexCoordScale;
 
    gl::GLuint mBlitFrameBuffers[2];
    gl::GLuint mFrameBuffer;

--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -428,6 +428,7 @@ bool GLDriver::checkActiveShader()
 
          // Get uniform locations
          vertexShader.uniformRegisters = gl::glGetUniformLocation(vertexShader.object, "VR");
+         vertexShader.uniformTexScale = gl::glGetUniformLocation(vertexShader.object, "texScale");
 
          // Get attribute locations
          vertexShader.attribLocations.fill(0);
@@ -485,6 +486,7 @@ bool GLDriver::checkActiveShader()
             // Get uniform locations
             pixelShader.uniformRegisters = gl::glGetUniformLocation(pixelShader.object, "PR");
             pixelShader.uniformAlphaRef = gl::glGetUniformLocation(pixelShader.object, "uAlphaRef");
+            pixelShader.uniformTexScale = gl::glGetUniformLocation(pixelShader.object, "texScale");
             pixelShader.sx_alpha_test_control = sx_alpha_test_control;
          }
 


### PR DESCRIPTION
Color buffer sizes can only be specified to tile granularity, while
texture sizes can be specified to texel granularity.  If a game renders
to an intermediate framebuffer with a non-tile-aligned effective size,
then sets that color buffer as a texture, the texture would be detected
as a separate surface due to the size difference, preventing the color
buffer's contents from being rendered.  (For example, Xenoblade uses
intermediate framebuffers of effective size 768x620 and 384x310, but
the framebuffer sizes are set to 768x624 and 384x320 respectively.)

This change allows surfaces to be resized as long as the guest surface
pitch remains unchanged.  To deal with differing sizes, texture
sampling calls multiply the texture coordinate with a scale factor
computed from the texture size specified by the program and the actual
OpenGL surface size.