### PR TITLE
decaf-sdl: Add joystick support.

### DIFF
--- a/src/decaf-sdl/config.h
+++ b/src/decaf-sdl/config.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <string>
+#include <vector>
+#include <common/cerealjsonoptionalinput.h> // for inline InputDevice load/save
 
 namespace config
 {
@@ -44,36 +46,200 @@ extern std::string level;
 namespace input
 {
 
+enum ControllerType {
+   None,
+   Keyboard,
+   Joystick,
+};
+
+// for inline InputDevice load/save
+extern std::string
+controllerTypeToString(ControllerType type);
+extern ControllerType
+controllerTypeFromString(const std::string &typeStr);
+
+struct InputDevice {
+   ControllerType type;
+   std::string name;
+
+   // For keyboard input, each entry is an SDL_SCANCODE_* constant; for
+   //  joystick input, each entry is the button number, or -2 to let SDL
+   //  choose an appropriate button.  In both cases, -1 means nothing is
+   //  assigned.
+
+   int button_up;
+   int button_down;
+   int button_left;
+   int button_right;
+   int button_a;
+   int button_b;
+   int button_x;
+   int button_y;
+   int button_trigger_r;
+   int button_trigger_l;
+   int button_trigger_zr;
+   int button_trigger_zl;
+   int button_stick_l;
+   int button_stick_r;
+   int button_plus;
+   int button_minus;
+   int button_home;
+   int button_sync;
+
+   union {
+      struct {
+         int left_stick_up;
+         int left_stick_down;
+         int left_stick_left;
+         int left_stick_right;
+         int right_stick_up;
+         int right_stick_down;
+         int right_stick_left;
+         int right_stick_right;
+      } keyboard;
+
+      struct {
+         int left_stick_x;
+         bool left_stick_x_invert;
+         int left_stick_y;
+         bool left_stick_y_invert;
+         int right_stick_x;
+         bool right_stick_x_invert;
+         int right_stick_y;
+         bool right_stick_y_invert;
+      } joystick;
+   };
+
+   // For some reason this has to be inline or cereal doesn't find it...
+
+   #define KEYBOARD_NVP(field)  cereal::make_nvp(#field, keyboard.field)
+   #define JOYSTICK_NVP(field)  cereal::make_nvp(#field, joystick.field)
+
+   template <class Archive>
+   void save(Archive &ar) const
+   {
+      ar(cereal::make_nvp("type", controllerTypeToString(type)),
+         CEREAL_NVP(name),
+         CEREAL_NVP(button_up),
+         CEREAL_NVP(button_down),
+         CEREAL_NVP(button_left),
+         CEREAL_NVP(button_right),
+         CEREAL_NVP(button_a),
+         CEREAL_NVP(button_b),
+         CEREAL_NVP(button_x),
+         CEREAL_NVP(button_y),
+         CEREAL_NVP(button_trigger_r),
+         CEREAL_NVP(button_trigger_l),
+         CEREAL_NVP(button_trigger_zr),
+         CEREAL_NVP(button_trigger_zl),
+         CEREAL_NVP(button_stick_l),
+         CEREAL_NVP(button_stick_r),
+         CEREAL_NVP(button_plus),
+         CEREAL_NVP(button_minus),
+         CEREAL_NVP(button_home),
+         CEREAL_NVP(button_sync));
+
+      switch (type) {
+      case input::None:  // suppress warnings
+         break;
+
+      case input::Keyboard:
+         ar(KEYBOARD_NVP(left_stick_up),
+            KEYBOARD_NVP(left_stick_down),
+            KEYBOARD_NVP(left_stick_left),
+            KEYBOARD_NVP(left_stick_right),
+            KEYBOARD_NVP(right_stick_up),
+            KEYBOARD_NVP(right_stick_down),
+            KEYBOARD_NVP(right_stick_left),
+            KEYBOARD_NVP(right_stick_right));
+         break;
+
+      case input::Joystick:
+         ar(JOYSTICK_NVP(left_stick_x),
+            JOYSTICK_NVP(left_stick_x_invert),
+            JOYSTICK_NVP(left_stick_y),
+            JOYSTICK_NVP(left_stick_y_invert),
+            JOYSTICK_NVP(right_stick_x),
+            JOYSTICK_NVP(right_stick_x_invert),
+            JOYSTICK_NVP(right_stick_y),
+            JOYSTICK_NVP(right_stick_y_invert));
+         break;
+      }
+   }
+
+   template <class Archive>
+   void load(Archive &ar)
+   {
+      std::string typeStr;
+      ar(typeStr,
+         CEREAL_NVP(name),
+         CEREAL_NVP(button_up),
+         CEREAL_NVP(button_down),
+         CEREAL_NVP(button_left),
+         CEREAL_NVP(button_right),
+         CEREAL_NVP(button_a),
+         CEREAL_NVP(button_b),
+         CEREAL_NVP(button_x),
+         CEREAL_NVP(button_y),
+         CEREAL_NVP(button_trigger_r),
+         CEREAL_NVP(button_trigger_l),
+         CEREAL_NVP(button_trigger_zr),
+         CEREAL_NVP(button_trigger_zl),
+         CEREAL_NVP(button_stick_l),
+         CEREAL_NVP(button_stick_r),
+         CEREAL_NVP(button_plus),
+         CEREAL_NVP(button_minus),
+         CEREAL_NVP(button_home),
+         CEREAL_NVP(button_sync));
+
+      type = controllerTypeFromString(typeStr);
+
+      switch (type) {
+      case input::None:  // suppress warnings
+         break;
+
+      case input::Keyboard:
+         ar(KEYBOARD_NVP(left_stick_up),
+            KEYBOARD_NVP(left_stick_down),
+            KEYBOARD_NVP(left_stick_left),
+            KEYBOARD_NVP(left_stick_right),
+            KEYBOARD_NVP(right_stick_up),
+            KEYBOARD_NVP(right_stick_down),
+            KEYBOARD_NVP(right_stick_left),
+            KEYBOARD_NVP(right_stick_right));
+         break;
+
+      case input::Joystick:
+         ar(JOYSTICK_NVP(left_stick_x),
+            JOYSTICK_NVP(left_stick_x_invert),
+            JOYSTICK_NVP(left_stick_y),
+            JOYSTICK_NVP(left_stick_y_invert),
+            JOYSTICK_NVP(right_stick_x),
+            JOYSTICK_NVP(right_stick_x_invert),
+            JOYSTICK_NVP(right_stick_y),
+            JOYSTICK_NVP(right_stick_y_invert));
+         break;
+      }
+   }
+
+   #undef KEYBOARD_NVP
+   #undef JOYSTICK_NVP
+};
+
+extern std::vector<InputDevice> devices;
+
 namespace vpad0
 {
 
+extern ControllerType type;
 extern std::string name;
-extern int button_up;
-extern int button_down;
-extern int button_left;
-extern int button_right;
-extern int button_a;
-extern int button_b;
-extern int button_x;
-extern int button_y;
-extern int button_trigger_r;
-extern int button_trigger_l;
-extern int button_trigger_zr;
-extern int button_trigger_zl;
-extern int button_stick_l;
-extern int button_stick_r;
-extern int button_plus;
-extern int button_minus;
-extern int button_home;
-extern int button_sync;
-extern int left_stick_x;
-extern int left_stick_y;
-extern int right_stick_x;
-extern int right_stick_y;
 
 } // namespace vpad0
 
 } // namespace input
+
+void
+initialize();
 
 bool
 load(const std::string &path,

--- a/src/decaf-sdl/decafsdl.cpp
+++ b/src/decaf-sdl/decafsdl.cpp
@@ -23,7 +23,7 @@ DecafSDL::~DecafSDL()
 bool
 DecafSDL::createWindow()
 {
-   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) != 0) {
+   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) != 0) {
       gCliLog->error("Failed to initialize SDL: {}", SDL_GetError());
       return false;
    }
@@ -109,6 +109,7 @@ DecafSDL::run(const std::string &gamePath)
    // Set input provider
    decaf::setInputDriver(this);
    decaf::addEventListener(this);
+   openInputDevices();
 
    // Set sound driver
    decaf::setSoundDriver(mSoundDriver);
@@ -161,6 +162,10 @@ DecafSDL::run(const std::string &gamePath)
    decaf::start();
 
    while (!shouldQuit && !decaf::hasExited()) {
+      if (mVpad0Controller) {
+         SDL_GameControllerUpdate();
+      }
+
       SDL_Event event;
 
       while (SDL_PollEvent(&event)) {

--- a/src/decaf-sdl/decafsdl.h
+++ b/src/decaf-sdl/decafsdl.h
@@ -6,6 +6,18 @@
 
 using namespace decaf::input;
 
+namespace config
+{
+
+namespace input
+{
+
+struct InputDevice;
+
+} // namespace input
+
+} // namespace config
+
 class DecafSDL : public decaf::InputDriver, public decaf::EventListener
 {
    static const auto WindowWidth = 1420;
@@ -38,6 +50,9 @@ private:
 
    void
    drawScanBuffers(gl::GLuint tvBuffer, gl::GLuint drcBuffer);
+
+   void
+   openInputDevices();
 
    decaf::input::KeyboardKey
    translateKeyCode(SDL_Keysym sym);
@@ -93,6 +108,9 @@ private:
    SDL_Window *mWindow = nullptr;
    SDL_GLContext mContext = nullptr;
    SDL_GLContext mThreadContext = nullptr;
+
+   const config::input::InputDevice *mVpad0Config = nullptr;
+   SDL_GameController *mVpad0Controller = nullptr;
 
    gl::GLuint mVertexProgram;
    gl::GLuint mPixelProgram;

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -34,6 +34,14 @@ getCommandLineParser()
                     optional {},
                     value<std::string> {});
 
+   auto input_options = parser.add_option_group("input Options")
+      .add_option("gamepad-type",
+                  description { "Select the input type for the emulated GamePad." },
+                  default_value<std::string> { "keyboard" },
+                  allowed<std::string> { {
+                     "none", "keyboard", "joystick"
+                  } });
+
    auto jit_options = parser.add_option_group("JIT Options")
       .add_option("jit",
                   description { "Enables the JIT engine." })
@@ -91,6 +99,7 @@ getCommandLineParser()
                   default_value<double> { 1.0 });
 
    parser.add_command("play")
+      .add_option_group(input_options)
       .add_option_group(jit_options)
       .add_option_group(log_options)
       .add_option_group(sys_options)
@@ -147,9 +156,24 @@ start(excmd::parser &parser,
       configPath = decaf::makeConfigPath("config.json");
    }
 
+   config::initialize();
    auto configLoaded = config::load(configPath, configError);
 
    // Allow command line options to override config
+   if (options.has("gamepad-type")) {
+       auto type = options.get<std::string>("gamepad-type");
+
+       if (type.compare("none") == 0) {
+           config::input::vpad0::type = config::input::None;
+       } else if (type.compare("keyboard") == 0) {
+           config::input::vpad0::type = config::input::Keyboard;
+       } else if (type.compare("joystick") == 0) {
+           config::input::vpad0::type = config::input::Joystick;
+       } else {
+           decaf_abort(fmt::format("Invalid input type {}", type));
+       }
+   }
+
    if (options.has("jit-verify")) {
       decaf::config::jit::verify = true;
    }


### PR DESCRIPTION
Also add support for keyboard axis input, assign keypad 8462 to the left
stick, and move the default stick button keys from C/D to keypad 0/Enter
so they're in the same place.